### PR TITLE
Bump the docker image tag to 1.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.1
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.2
 
 build: .built-image
 


### PR DESCRIPTION
I think I must have pushed different versions of 1.1 to docker
hub, because 1.1 was running in the cluster, but was missing the
html which adds the link to github.

This commit bumps the version number, but makes no other changes,
so that I can update the deployment to use the latest image.