### PR TITLE
Display total resources requested, above the chart

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,11 +21,16 @@ def namespaces_data(order_by)
     values: values,
     last_updated: DateTime.parse(namespaces["last_updated"]),
     type: order_by,
+    total_requested: total_requested_by_all_namespaces(order_by), # order_by is cpu|memory
   }
 end
 
 def namespace(name)
   namespaces["items"].find { |n| n["name"] == params[:name] }
+end
+
+def total_requested_by_all_namespaces(property)
+  namespaces["items"].map { |ns| ns.dig("max_requests", property) }.map(&:to_i).sum
 end
 
 ############################################################

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.2
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.4
 
 build: .built-image
 

--- a/views/namespaces_chart.erb
+++ b/views/namespaces_chart.erb
@@ -111,6 +111,9 @@
 
   <body>
     <p class="last_updated">Last updated: <%= last_updated.strftime("%Y-%m-%d %H:%M:%S") %> UTC. Updated every 30 minutes</p>
+    <p>
+      Total requested: <%= total_requested %>
+    </p>
     <!--Div that will hold the pie chart-->
     <div id="chart_div"></div>
   </body>


### PR DESCRIPTION
Show the total CPU/memory requested by all namespaces.

This will make it easier for us to decide when we can scale down the cluster.