### PR TITLE
Add a bar showing pod request totals

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -29,7 +29,8 @@ def namespace_values(namespace, order_by)
   [
     namespace.fetch("name").to_s,
     namespace.dig("max_requests", order_by).to_i,
-    namespace.dig("resources_used", order_by).to_i
+    namespace.dig("resources_requested", order_by).to_i,
+    namespace.dig("resources_used", order_by).to_i,
   ]
 end
 
@@ -48,7 +49,7 @@ get "/" do
 end
 
 get "/namespaces_by_cpu" do
-  column_titles = [ "Namespaces", "CPU requested (millicores)", "CPU used (millicores)" ]
+  column_titles = [ "Namespaces", "Namespace CPU request (millicores)", "Total pod requests (millicores)", "CPU used (millicores)" ]
 
   locals = namespaces_data("cpu").merge(
     column_titles: column_titles,
@@ -61,7 +62,7 @@ rescue Errno::ENOENT
 end
 
 get "/namespaces_by_memory" do
-  column_titles = [ "Namespaces", "Memory requested (mebibytes)", "Memory used (mebibytes)" ]
+  column_titles = [ "Namespaces", "Namespace memory request (mebibytes)", "Total pods requests (mebibytes)", "Memory used (mebibytes)" ]
 
   locals = namespaces_data("memory").merge(
     column_titles: column_titles,

--- a/app.rb
+++ b/app.rb
@@ -21,11 +21,16 @@ def namespaces_data(order_by)
     values: values,
     last_updated: DateTime.parse(namespaces["last_updated"]),
     type: order_by,
+    total_requested: total_requested_by_all_namespaces(order_by), # order_by is cpu|memory
   }
 end
 
 def namespace(name)
   namespaces["items"].find { |n| n["name"] == params[:name] }
+end
+
+def total_requested_by_all_namespaces(property)
+  namespaces["items"].map { |ns| ns.dig("max_requests", property) }.map(&:to_i).sum
 end
 
 ############################################################

--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,7 @@ end
 
 def namespaces_data(order_by)
   values = namespaces["items"]
-    .map { |n| [ n.fetch("name").to_s, n.dig("max_requests", order_by).to_i, n.dig("resources_used", order_by).to_i ] }
+    .map { |n| namespace_values(n, order_by) }
     .sort_by { |i| i[1] }
     .reverse
 
@@ -23,6 +23,14 @@ def namespaces_data(order_by)
     type: order_by,
     total_requested: total_requested_by_all_namespaces(order_by), # order_by is cpu|memory
   }
+end
+
+def namespace_values(namespace, order_by)
+  [
+    namespace.fetch("name").to_s,
+    namespace.dig("max_requests", order_by).to_i,
+    namespace.dig("resources_used", order_by).to_i
+  ]
 end
 
 def namespace(name)

--- a/makefile
+++ b/makefile
@@ -12,3 +12,10 @@ run: build
 		-p 4567:4567 \
 		-e API_KEY=soopersekrit \
 		-it $(IMAGE)
+
+# Ensure you have a data/namespace-report.json file
+# NB: you will have to restart this process when you
+# change files. Most changes will not be picked up by
+# just reloading the web page.
+dev-server:
+	./app.rb -o 0.0.0.0

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.4
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.5
 
 build: .built-image
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.2
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.4
 
 build: .built-image
 

--- a/views/namespaces_chart.erb
+++ b/views/namespaces_chart.erb
@@ -110,7 +110,7 @@
   </head>
 
   <body>
-    <p class="last_updated">Last updated: <%= last_updated.strftime("%Y-%m-%d %H:%M:%S") %></p>
+    <p class="last_updated">Last updated: <%= last_updated.strftime("%Y-%m-%d %H:%M:%S") %> UTC. Updated every 30 minutes</p>
     <!--Div that will hold the pie chart-->
     <div id="chart_div"></div>
   </body>

--- a/views/namespaces_chart.erb
+++ b/views/namespaces_chart.erb
@@ -46,6 +46,7 @@
           'width':1500,
           'height':<%= values.count * 50 %>,
           'chartArea': { 'top': 50 },
+          'colors': ['blue', 'orange', 'red']
         };
 
         // Instantiate and draw our chart, passing in some options.

--- a/views/namespaces_chart.erb
+++ b/views/namespaces_chart.erb
@@ -37,6 +37,7 @@
         data.addColumn('string', '<%= column_titles[0] %>');
         data.addColumn('number', '<%= column_titles[1] %>');
         data.addColumn('number', '<%= column_titles[2] %>');
+        data.addColumn('number', '<%= column_titles[3] %>');
         data.addRows(<%= values %>);
 
         // Set chart options

--- a/views/namespaces_chart.erb
+++ b/views/namespaces_chart.erb
@@ -111,6 +111,9 @@
 
   <body>
     <p class="last_updated">Last updated: <%= last_updated.strftime("%Y-%m-%d %H:%M:%S") %> UTC. Updated every 30 minutes</p>
+    <p>
+      Total requested: <%= total_requested %>
+    </p>
     <!--Div that will hold the pie chart-->
     <div id="chart_div"></div>
   </body>


### PR DESCRIPTION
As well as the overall namespace resource requests, it's
useful to see the sum total of all resource requests by
pods in the namespace.

This allows us to see when we can safely reduce the
namespace resourcequota request values without impacting
the workloads running in a namespace.