### PR TITLE
Report total of pod requests, not resourcequota

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -65,7 +65,7 @@ def namespace(name)
 end
 
 def total_requested_by_all_namespaces(property)
-  namespaces["items"].map { |ns| ns.dig("max_requests", property) }.map(&:to_i).sum
+  namespaces["items"].map { |ns| ns.dig("resources_requested", property) }.map(&:to_i).sum
 end
 
 ############################################################

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.6
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.7
 
 build: .built-image
 


### PR DESCRIPTION
related to https://github.com/ministryofjustice/cloud-platform-environments/pull/1534

We used to set CPU and memory request limits for
namespaces, so the namespace reporter displayed
the total of all resourcequota namespace requests
to show how much cluster resource was committed.

Now that we have removed namespace request limits
that value will always be zero, so the code needs 
to change to report the total of all CPU/memory 
requests by all *pods*.