### PR TITLE
Show total pods running on the pods page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,11 +35,13 @@ def namespaces_pods_data
     .sort_by { |i| i[1] }
     .reverse
 
+  total_pods = namespaces["items"].sum { |n| n.dig("resources_used", "pods") }
+
   {
     values: values,
     last_updated: DateTime.parse(namespaces["last_updated"]),
     type: "pods",
-    total_requested: 0,
+    total_requested: total_pods,
   }
 end
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.6
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.8
 
 build: .built-image
 

--- a/makefile
+++ b/makefile
@@ -11,6 +11,7 @@ run: build
 	docker run --rm \
 		-p 4567:4567 \
 		-e API_KEY=soopersekrit \
+		-e RACK_ENV=production \
 		-it $(IMAGE)
 
 # Ensure you have a data/namespace-report.json file


### PR DESCRIPTION
Rather than showing "Total requested: 0", this change displays the total
number of pods running in all namespaces.

This isn't a very useful number, but it's more intereting than zero.

depends on #8