### PR TITLE
Add gitops deployment dir and fix exceeded available parameter key space error

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,8 @@ require "bundler/setup"
 require "json"
 require "sinatra"
 
+Rack::Utils.key_space_limit = 262144
+
 if development?
   require "sinatra/reloader"
   require "pry-byebug"

--- a/cloud-platform-deploy/namespace-usage-report/cronjob.yaml
+++ b/cloud-platform-deploy/namespace-usage-report/cronjob.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: report-generator
+  namespace: namespace-usage-report
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: report-generator-serviceaccount
+          restartPolicy: Never
+          containers:
+            - name: report-generator
+              image: ministryofjustice/namespace-report-generator:1.0
+              command:
+                - ./update-data.sh
+              env:
+                - name: WEB_APP_URL
+                  value: "http://usage-report-service:4567/update-data"
+                - name: API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: usage-report-api-key
+                      key: token

--- a/cloud-platform-deploy/namespace-usage-report/deployment.yaml
+++ b/cloud-platform-deploy/namespace-usage-report/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: usage-report
+  namespace: namespace-usage-report
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: usage-report-app
+    spec:
+      containers:
+        - name: usage-report
+          image: ministryofjustice/cloud-platform-namespace-usage-report:1.9
+          env:
+            - name: RACK_ENV
+              value: "production"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: usage-report-api-key
+                  key: token
+          ports:
+          - containerPort: 4567

--- a/cloud-platform-deploy/namespace-usage-report/ingress.yaml
+++ b/cloud-platform-deploy/namespace-usage-report/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: usage-report-app-ingress
+  namespace: namespace-usage-report
+spec:
+  tls:
+  - hosts:
+    - namespace-usage-report.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: namespace-usage-report.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: usage-report-service
+          servicePort: 4567

--- a/cloud-platform-deploy/namespace-usage-report/service-account.yaml
+++ b/cloud-platform-deploy/namespace-usage-report/service-account.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: report-generator-serviceaccount
+  namespace: namespace-usage-report
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: report-generator-role
+  namespace: namespace-usage-report
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods", "limitranges", "resourcequotas"]
+    verbs:
+      - list
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs:
+      - get
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: report-generator-rolebinding
+  namespace: namespace-usage-report
+subjects:
+- kind: ServiceAccount
+  name: report-generator-serviceaccount
+  namespace: namespace-usage-report
+roleRef:
+  kind: ClusterRole
+  name: report-generator-role
+  apiGroup: rbac.authorization.k8s.io

--- a/cloud-platform-deploy/namespace-usage-report/service.yaml
+++ b/cloud-platform-deploy/namespace-usage-report/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: usage-report-service
+  labels:
+    app: usage-report-service
+spec:
+  ports:
+  - port: 4567
+    name: https
+    targetPort: 4567
+  selector:
+    app: usage-report-app

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.8
+IMAGE := ministryofjustice/cloud-platform-namespace-usage-report:1.9
 
 build: .built-image
 


### PR DESCRIPTION
TLDR;
---
- Adds Cloud Platform deploy dir and stores kubernetes manifests.
- Fixes `exceeded available parameter key space` error when dealing with large data.
- Bumps the image tag.

Why
---
This is the first application to use the gitops pipeline and will need this directory. The error was causing the page to fail to load. 